### PR TITLE
Add support for the currency bitcoin

### DIFF
--- a/Format/Currency.swift
+++ b/Format/Currency.swift
@@ -60,6 +60,8 @@ public enum Currency: NumberFormatter {
     case BRL
     /// Bahamas Dollar
     case BSD
+    /// Bitcoin
+    case BTC
     /// Bhutan Ngultrum
     case BTN
     /// Botswana Pula
@@ -384,6 +386,8 @@ public enum Currency: NumberFormatter {
             return "BSD"
         case BTN:
             return "BTN"
+        case BTC:
+            return "BTC"
         case BWP:
             return "BWP"
         case BYR:

--- a/Format/NumberFormatter.swift
+++ b/Format/NumberFormatter.swift
@@ -65,6 +65,11 @@ public class NumberFormat {
         }
         if (formatter.type == .Currency){
             nsFormatter.currencyCode = formatter.modifier
+            if (nsFormatter.currencyCode == Currency.BTC.modifier) {
+                nsFormatter.currencySymbol = "Ƀ";
+            } else {
+                nsFormatter.currencySymbol = nil;
+            }
             formattedString = nsFormatter.stringFromNumber(number)
         }
         if (formatter.type == .General){

--- a/FormatTests/NumberFormatterTests.swift
+++ b/FormatTests/NumberFormatterTests.swift
@@ -63,6 +63,8 @@ class NumberFormatterTests: XCTestCase {
         let frenchLocale = NSLocale(localeIdentifier: "FR")
         let formattedNumberEUR = number.format(Currency.EUR, locale: frenchLocale)
         XCTAssertEqual(formattedNumberEUR, "45,23 €")
+        let formattedNumberBTC = number.format(Currency.BTC, locale: frenchLocale)
+        XCTAssertEqual(formattedNumberBTC, "45,23 Ƀ")
         let formattedNumberGBP = number.format(Currency.GBP)
         XCTAssertEqual(formattedNumberGBP, "£45.23")
         let formattedNumberUSD = number.format(Currency.USD)
@@ -71,6 +73,8 @@ class NumberFormatterTests: XCTestCase {
     
     func testCurrencyFormattingInt() {
         let number = 45
+        let formattedNumberBTC = number.format(Currency.BTC)
+        XCTAssertEqual(formattedNumberBTC, "Ƀ45.00")
         let formattedNumberEUR = number.format(Currency.EUR)
         XCTAssertEqual(formattedNumberEUR, "€45.00")
         let formattedNumberGBP = number.format(Currency.GBP)


### PR DESCRIPTION
This PR adds support for digital currency bitcoin. Since the `NSNumberFormatter` does not provide a symbol for the BTC, I decided to adopt the symbol [`Ƀ`](http://bitcoinsymbol.org/). I also decided to [move the instantiation of the `NSNumberFormatter` to the `format`method](https://github.com/marmelroy/Format/compare/master...SandroMachado:feature/add-support-for-bitcoin-currency?expand=1#diff-16a264965c9ed9060c55cd6daf1992b9R50) because I experienced some concurrency issues running the testes. 