### PR TITLE
Xcode 7 Swift 2.0 Compilation Fix

### DIFF
--- a/Format/NumberExtensions.swift
+++ b/Format/NumberExtensions.swift
@@ -146,7 +146,7 @@ extension Int64: NumberFormatProvider {
 
 extension UInt: NumberFormatProvider {
     public func formatNumber() -> NSNumber {
-        return NSNumber(unsignedLong: self)
+        return NSNumber(unsignedInteger: self)
     }
 }
 

--- a/Format/NumberExtensions.swift
+++ b/Format/NumberExtensions.swift
@@ -146,7 +146,7 @@ extension Int64: NumberFormatProvider {
 
 extension UInt: NumberFormatProvider {
     public func formatNumber() -> NSNumber {
-        return NSNumber(unsignedInteger: self)
+        return NSNumber(unsignedLong: self)
     }
 }
 


### PR DESCRIPTION
# Release Notes

- Compiler was complaining that ```unsignedInteger``` was not allowed for ```UInt's```, so I switched to ```unsignedLong```